### PR TITLE
Asus USB-N13 support

### DIFF
--- a/common/rtusb_dev_id.c
+++ b/common/rtusb_dev_id.c
@@ -52,6 +52,7 @@ USB_DEVICE_ID rtusb_dev_id[] = {
 	{USB_DEVICE(0x148F,0x3573)}, /* Ralink 3573 */
 	{USB_DEVICE(0x7392,0x7733)}, /* Edimax */
 	{USB_DEVICE(0x0846,0x9012)}, /* Netgear WNDA4100 N900*/
+	{USB_DEVICE(0x0b05,0x1784)}, /* Asus USB-N13 */
 #endif /* RT3573 */
 	{ }/* Terminating entry */
 };


### PR DESCRIPTION
Thank you very much for this! You've suddenly cured my awful headache.

Here's the device ID for the Asus USB-N13, which, so far, works perfectly with your drivers.
