### PR TITLE
Add cisco AE3000 support

### DIFF
--- a/common/rtusb_dev_id.c
+++ b/common/rtusb_dev_id.c
@@ -56,6 +56,7 @@ USB_DEVICE_ID rtusb_dev_id[] = {
 	{USB_DEVICE(0x0b05,0x1784)}, /* Asus USB-N13 */
     {USB_DEVICE(0x0B05,0x17AD)}, /* ASUS USB-N66 */
 	{USB_DEVICE(0x0df6,0x006e)}, /* Sitecom WLA-6100 */
+	{USB_DEVICE(0x13B1,0x003B)}, /* Cisco LinkSys AE3000 */
 #endif /* RT3573 */
 	{ }/* Terminating entry */
 };


### PR DESCRIPTION
Fix found here: http://geekniggle.blogspot.fr/2012/07/cisco-linksys-ae3000-wifi-usb-dongle.html to add AE3000 dongle support
